### PR TITLE
Fix fullscreen shortcode mounting

### DIFF
--- a/Wordpress Plugin/n8n-brandable-chatbox/assets/js/n8n-brandable-chatbox.js
+++ b/Wordpress Plugin/n8n-brandable-chatbox/assets/js/n8n-brandable-chatbox.js
@@ -25,7 +25,9 @@
       transformRequest: null, // (text, ctx) => payload
       transformResponse: null, // (data) => string | { text, html }
       maxMessages: 200,
-      sessionTtlMinutes: 0 // 0 disables inactivity expiration
+      sessionTtlMinutes: 0, // 0 disables inactivity expiration
+      displayMode: "widget", // 'widget' | 'fullscreen'
+      mountId: null
     };
 
     function generateSessionId() {
@@ -47,26 +49,59 @@
       return temp.innerHTML;
     }
 
-    function createShadowRoot(zIndex) {
+    function createShadowRoot(options) {
       const host = document.createElement("div");
       host.setAttribute("data-bc-root", "true");
       host.style.all = "initial";
-      host.style.position = "fixed";
-      host.style.zIndex = String(zIndex);
-      document.body.appendChild(host);
+
+      const mountId = typeof options.mountId === "string" ? options.mountId : "";
+      let mountTarget = mountId ? document.getElementById(mountId) : null;
+      if (!mountTarget) {
+        mountTarget = document.body;
+      }
+
+      const isFullscreen = options.displayMode === "fullscreen";
+      const targetComputed = mountTarget === document.body ? null : window.getComputedStyle(mountTarget);
+      if (mountTarget && mountTarget !== document.body && targetComputed && targetComputed.position === "static") {
+        mountTarget.style.position = "relative";
+      }
+
+      if (isFullscreen && mountTarget && mountTarget !== document.body) {
+        host.style.position = "absolute";
+        host.style.top = "0";
+        host.style.right = "0";
+        host.style.bottom = "0";
+        host.style.left = "0";
+        host.style.width = "100%";
+        host.style.height = "100%";
+      } else {
+        host.style.position = "fixed";
+        host.style.top = "0";
+        host.style.left = "0";
+        if (isFullscreen) {
+          host.style.right = "0";
+          host.style.bottom = "0";
+          host.style.width = "100vw";
+          host.style.height = "100vh";
+        }
+      }
+
+      host.style.zIndex = String(options.zIndex);
+      mountTarget.appendChild(host);
       return host.attachShadow({ mode: "open" });
     }
 
     function createStyles(options) {
+      const isFullscreen = options.displayMode === "fullscreen";
       const css = `
       :host { all: initial; }
       *, *::before, *::after { box-sizing: border-box; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; }
       
       /* Container - ensure it's always positioned relative to viewport */
-      .bc-container { 
-        position: fixed !important; 
-        ${options.position === "left" ? "left" : "right"}: max(20px, env(safe-area-inset-${options.position === "left" ? "left" : "right"}, 20px)); 
-        bottom: max(20px, env(safe-area-inset-bottom, 20px)) !important; 
+      .bc-container {
+        position: fixed !important;
+        ${options.position === "left" ? "left" : "right"}: max(20px, env(safe-area-inset-${options.position === "left" ? "left" : "right"}, 20px));
+        bottom: max(20px, env(safe-area-inset-bottom, 20px)) !important;
         z-index: ${options.zIndex};
         pointer-events: none;
       }
@@ -95,8 +130,8 @@
 
       /* Panel - ensure it's positioned correctly relative to launcher */
       .bc-panel {
-        position: absolute !important; 
-        ${options.position === "left" ? "left" : "right"}: 0; 
+        position: absolute !important;
+        ${options.position === "left" ? "left" : "right"}: 0;
         bottom: 72px;
         width: min(380px, calc(100vw - 40px));
         min-height: 340px;
@@ -190,6 +225,44 @@
           bottom: max(20px, env(safe-area-inset-bottom));
         }
       }
+      ${isFullscreen ? `
+      .bc-container {
+        position: absolute !important;
+        top: 0 !important;
+        left: 0 !important;
+        right: 0 !important;
+        bottom: 0 !important;
+        width: 100% !important;
+        height: 100% !important;
+        pointer-events: auto !important;
+      }
+      .bc-panel {
+        top: 0 !important;
+        left: 0 !important;
+        right: 0 !important;
+        bottom: 0 !important;
+        width: 100% !important;
+        height: 100% !important;
+        max-height: none !important;
+        border-radius: 0 !important;
+        box-shadow: none !important;
+        background: ${options.darkMode ? "#0b1220" : "#ffffff"} !important;
+        -webkit-backdrop-filter: none !important;
+        backdrop-filter: none !important;
+      }
+      .bc-panel.hidden {
+        opacity: 0 !important;
+        transform: none !important;
+        pointer-events: none !important;
+        display: none !important;
+      }
+      .bc-launcher {
+        display: none !important;
+      }
+      .bc-close {
+        display: none !important;
+      }
+      ` : ""}
       `;
       const style = document.createElement("style");
       style.textContent = css;
@@ -199,23 +272,27 @@
     function createUI(options, shadowRoot) {
       const container = document.createElement("div");
       container.className = "bc-container";
+      const isFullscreen = options.displayMode === "fullscreen";
 
-      const launcher = document.createElement("button");
-      launcher.className = "bc-launcher";
-      launcher.setAttribute("aria-label", options.launcherText || `Open ${options.botName}`);
-      const iconSvg = `
-        <svg viewBox="0 0 24 24" fill="none">
-          <path d="M12 3C7.03 3 3 6.58 3 11c0 2.43 1.23 4.61 3.19 6.11-.09.76-.39 2.02-1.31 3.16 0 0 2.06-.21 3.76-1.45.73.2 1.5.31 2.36.31 4.97 0 9-3.58 9-8s-4.03-8-9-8z" fill="currentColor"/>
-        </svg>`;
-      const launchText = options.launcherText || `Chat`;
-      if (options.launcherVariant === 'text') {
-        launcher.classList.add('bc-launcher--text');
-        launcher.innerHTML = `<span>${launchText}</span>`;
-      } else if (options.launcherVariant === 'icon-text') {
-        launcher.classList.add('bc-launcher--icon-text');
-        launcher.innerHTML = iconSvg + `<span>${launchText}</span>`;
-      } else {
-        launcher.innerHTML = iconSvg;
+      let launcher = null;
+      if (!isFullscreen) {
+        launcher = document.createElement("button");
+        launcher.className = "bc-launcher";
+        launcher.setAttribute("aria-label", options.launcherText || `Open ${options.botName}`);
+        const iconSvg = `
+          <svg viewBox="0 0 24 24" fill="none">
+            <path d="M12 3C7.03 3 3 6.58 3 11c0 2.43 1.23 4.61 3.19 6.11-.09.76-.39 2.02-1.31 3.16 0 0 2.06-.21 3.76-1.45.73.2 1.5.31 2.36.31 4.97 0 9-3.58 9-8s-4.03-8-9-8z" fill="currentColor"/>
+          </svg>`;
+        const launchText = options.launcherText || `Chat`;
+        if (options.launcherVariant === "text") {
+          launcher.classList.add("bc-launcher--text");
+          launcher.innerHTML = `<span>${launchText}</span>`;
+        } else if (options.launcherVariant === "icon-text") {
+          launcher.classList.add("bc-launcher--icon-text");
+          launcher.innerHTML = iconSvg + `<span>${launchText}</span>`;
+        } else {
+          launcher.innerHTML = iconSvg;
+        }
       }
 
       const panel = document.createElement("div");
@@ -251,7 +328,9 @@
       powered.innerHTML = `Developed by <a href="https://www.omerfayyaz.com" target="_blank" rel="noopener noreferrer">Omer Fayyaz</a>`;
       panel.appendChild(powered);
       container.appendChild(panel);
-      container.appendChild(launcher);
+      if (launcher) {
+        container.appendChild(launcher);
+      }
 
       shadowRoot.appendChild(container);
 
@@ -320,6 +399,9 @@
 
     function init(userOptions) {
       const options = { ...defaultOptions, ...userOptions };
+      if (options.displayMode === "fullscreen") {
+        options.openByDefault = true;
+      }
       if (!options.webhookUrl) {
         console.error("[N8NbrandableChatbox] Missing required option: webhookUrl");
         return;
@@ -342,7 +424,7 @@
         }
       }
 
-      const shadowRoot = createShadowRoot(options.zIndex);
+      const shadowRoot = createShadowRoot(options);
       const styleEl = createStyles(options);
       shadowRoot.appendChild(styleEl);
       const ui = createUI(options, shadowRoot);
@@ -386,7 +468,9 @@
       }
 
       function reopenFromOption() {
-        if (options.openByDefault) ui.panel.classList.remove("hidden");
+        if (options.openByDefault || options.displayMode === "fullscreen") {
+          ui.panel.classList.remove("hidden");
+        }
       }
 
       // Restore history
@@ -472,10 +556,12 @@
       }
 
       // Events
-      ui.launcher.addEventListener("click", () => {
-        ui.panel.classList.toggle("hidden");
-        if (typeof options.onEvent === "function") options.onEvent("toggle", { open: !ui.panel.classList.contains("hidden") });
-      });
+      if (ui.launcher) {
+        ui.launcher.addEventListener("click", () => {
+          ui.panel.classList.toggle("hidden");
+          if (typeof options.onEvent === "function") options.onEvent("toggle", { open: !ui.panel.classList.contains("hidden") });
+        });
+      }
       ui.header.querySelector(".bc-close").addEventListener("click", () => {
         ui.panel.classList.add("hidden");
         if (typeof options.onEvent === "function") options.onEvent("toggle", { open: false });

--- a/Wordpress Plugin/n8n-brandable-chatbox/n8n-brandable-chatbox.php
+++ b/Wordpress Plugin/n8n-brandable-chatbox/n8n-brandable-chatbox.php
@@ -22,6 +22,7 @@ class N8N_Brandable_Chatbox_Plugin {
         add_action('wp_enqueue_scripts', [$this, 'enqueue_frontend_assets']);
         add_action('wp_footer', [$this, 'maybe_auto_inject'], 999);
         add_shortcode('n8n_brandable_chatbox', [$this, 'shortcode_handler']);
+        add_shortcode('n8n_brandable_chatbox_fullscreen', [$this, 'fullscreen_shortcode_handler']);
     }
 
     private function get_default_options() {
@@ -52,6 +53,7 @@ class N8N_Brandable_Chatbox_Plugin {
             'session_ttl_minutes' => 0,
             'auto_inject' => false,
             'dispatch_events' => false,
+            'display_mode' => 'widget',
         ];
     }
 
@@ -158,6 +160,7 @@ class N8N_Brandable_Chatbox_Plugin {
         $out['session_ttl_minutes'] = isset($input['session_ttl_minutes']) ? max(0, intval($input['session_ttl_minutes'])) : 0;
         $out['auto_inject'] = !empty($input['auto_inject']) ? true : false;
         $out['dispatch_events'] = !empty($input['dispatch_events']) ? true : false;
+        $out['display_mode'] = isset($input['display_mode']) && in_array($input['display_mode'], ['widget', 'fullscreen'], true) ? $input['display_mode'] : $defaults['display_mode'];
         return $out;
     }
 
@@ -172,7 +175,7 @@ class N8N_Brandable_Chatbox_Plugin {
         do_settings_sections('n8n-brandable-chatbox');
         submit_button();
         echo '</form>';
-        echo '<p><strong>Shortcode:</strong> [n8n_brandable_chatbox]</p>';
+        echo '<p><strong>Shortcodes:</strong> [n8n_brandable_chatbox] or [n8n_brandable_chatbox_fullscreen]</p>';
         echo '<p><strong>Note:</strong> For headers/extra context, provide valid JSON objects.</p>';
         echo '</div>';
     }
@@ -228,6 +231,8 @@ class N8N_Brandable_Chatbox_Plugin {
             'extraContext' => $extra,
             'maxMessages' => (int) $opts['max_messages'],
             'sessionTtlMinutes' => (int) $opts['session_ttl_minutes'],
+            'displayMode' => $opts['display_mode'],
+            'mountId' => isset($opts['mount_id']) ? $opts['mount_id'] : '',
         ];
 
         $config_json = wp_json_encode($config);
@@ -271,6 +276,7 @@ class N8N_Brandable_Chatbox_Plugin {
             'max_messages' => '',
             'session_ttl_minutes' => '',
             'dispatch_events' => '',
+            'display_mode' => '',
         ], $atts, 'n8n_brandable_chatbox');
 
         $overrides = [];
@@ -280,15 +286,40 @@ class N8N_Brandable_Chatbox_Plugin {
                     $overrides[$k] = filter_var($v, FILTER_VALIDATE_BOOLEAN);
                 } elseif (in_array($k, ['z_index','max_messages','session_ttl_minutes'], true)) {
                     $overrides[$k] = intval($v);
+                } elseif ($k === 'display_mode') {
+                    $mode = strtolower($v);
+                    if (in_array($mode, ['widget', 'fullscreen'], true)) {
+                        $overrides[$k] = $mode;
+                    }
                 } else {
                     $overrides[$k] = $v;
                 }
             }
         }
 
+        $placeholder_id = '';
+        if (isset($overrides['display_mode']) && $overrides['display_mode'] === 'fullscreen') {
+            $placeholder_id = 'n8n-chatbox-' . wp_generate_uuid4();
+            $overrides['mount_id'] = $placeholder_id;
+        }
+
         ob_start();
+        if ($placeholder_id) {
+            printf(
+                '<div id="%1$s" class="n8n-brandable-chatbox-fullscreen" style="position:relative;width:100%%;min-height:100vh;"></div>',
+                esc_attr($placeholder_id)
+            );
+        }
         $this->output_init_script($overrides);
         return ob_get_clean();
+    }
+
+    public function fullscreen_shortcode_handler($atts = []) {
+        $atts['display_mode'] = 'fullscreen';
+        if (!isset($atts['open_by_default'])) {
+            $atts['open_by_default'] = 'true';
+        }
+        return $this->shortcode_handler($atts);
     }
 }
 

--- a/Wordpress Plugin/n8n-brandable-chatbox/readme.txt
+++ b/Wordpress Plugin/n8n-brandable-chatbox/readme.txt
@@ -18,9 +18,12 @@ This plugin embeds a lightweight chat widget on your site and sends user message
 3. Go to Settings → Brandable Custom Chatbox for N8N and set your Webhook URL and options.
 
 == Usage ==
-- Shortcode: `[n8n_brandable_chatbox]`
-  - Attributes (optional): `webhook_url, brand_color, accent_color, bot_name, bot_avatar_url, user_avatar_url, welcome_message, launcher_text, launcher_variant, position, z_index, open_by_default, placeholder, storage_key, typing_indicator_text, dark_mode, allow_html, headers_json, extra_context_json, response_field, max_messages, session_ttl_minutes, dispatch_events`.
+- Shortcodes:
+  - Widget: `[n8n_brandable_chatbox]`
+  - Fullscreen: `[n8n_brandable_chatbox_fullscreen]`
+  - Shared attributes (optional): `webhook_url, brand_color, accent_color, bot_name, bot_avatar_url, user_avatar_url, welcome_message, launcher_text, launcher_variant, position, z_index, open_by_default, placeholder, storage_key, typing_indicator_text, dark_mode, allow_html, headers_json, extra_context_json, response_field, max_messages, session_ttl_minutes, dispatch_events`.
   - `launcher_variant` accepts `icon`, `text`, or `icon-text`.
+  - The fullscreen shortcode automatically opens the chat and hides the floating launcher.
 - Auto-inject: Enable “Auto-inject on all pages” in settings.
   - Optional: “Dispatch window CustomEvents” to receive events on `window` like `n8nbrandablechatbox:ready`, `n8nbrandablechatbox:toggle`, `n8nbrandablechatbox:message`, `n8nbrandablechatbox:error`.
 


### PR DESCRIPTION
## Summary
- ensure the fullscreen shortcode outputs a mounting placeholder so the chat can occupy the full page content
- allow the frontend script to target a provided mount element and stretch the fullscreen layout accordingly

## Testing
- php -l 'Wordpress Plugin/n8n-brandable-chatbox/n8n-brandable-chatbox.php'


------
https://chatgpt.com/codex/tasks/task_b_68cad50dd848832f82b21a6fe51e1291